### PR TITLE
feat: add request deduplication logic as Idempotent Receiver pattern

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ max-line-length = 140
 select = ["C", "E", "F", "W", "B", "B9"]
 ignore = ["E203", "E501", "W503", "C812", "E731", "F811"]
 exclude = ["__init__.py"]
+extend-immutable-calls = ["Query", "fastapi.Query"]
 
 [tool.black]
 line-length = 140

--- a/src/pydistributedkv/domain/models.py
+++ b/src/pydistributedkv/domain/models.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 class OperationType(str, Enum):
     SET = "SET"
     DELETE = "DELETE"
+    GET = "GET"
 
 
 class LogEntry(BaseModel):
@@ -43,6 +44,16 @@ class KeyValue(BaseModel):
 class ReplicationStatus(BaseModel):
     follower_id: str
     last_replicated_id: int
+
+
+class ClientRequest(BaseModel):
+    """Request from a client with unique identifiers to enable idempotent processing"""
+
+    client_id: str
+    request_id: str
+    operation: Optional[OperationType] = None
+    key: Optional[str] = None
+    value: Optional[Any] = None
 
 
 class ReplicationRequest(BaseModel):

--- a/src/pydistributedkv/entrypoints/web/leader/leader.py
+++ b/src/pydistributedkv/entrypoints/web/leader/leader.py
@@ -1,11 +1,18 @@
+import logging
 import os
+from typing import Optional
 
 import requests
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Query
 
 from pydistributedkv.configurator.settings.base import API_TIMEOUT, MAX_SEGMENT_SIZE
-from pydistributedkv.domain.models import FollowerRegistration, KeyValue, WAL
+from pydistributedkv.domain.models import ClientRequest, FollowerRegistration, KeyValue, WAL
+from pydistributedkv.service.request_deduplication import RequestDeduplicationService
 from pydistributedkv.service.storage import KeyValueStorage
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 app = FastAPI()
 
@@ -13,57 +20,142 @@ app = FastAPI()
 wal = WAL(os.getenv("WAL_PATH", "data/leader/wal.log"), max_segment_size=MAX_SEGMENT_SIZE)
 storage = KeyValueStorage(wal)
 
+# Request deduplication service
+request_deduplication = RequestDeduplicationService(service_name="leader")
+
 # Track followers and their replication status
 followers: dict[str, str] = {}  # follower_id -> url
 replication_status: dict[str, int] = {}  # follower_id -> last_replicated_id
 
 
 @app.get("/key/{key}")
-def get_key(key: str):
+def get_key(key: str, client_id: Optional[str] = Query(None), request_id: Optional[str] = Query(None)):
+    # Track request with client identifiers if provided
+    if client_id and request_id:
+        logger.info(f"GET request for key={key} from client={client_id}, request={request_id}")
+        previous_response = request_deduplication.get_processed_result(client_id, request_id)
+        if previous_response is not None:
+            logger.info(f"✅ Returning cached response for GET key={key}, client={client_id}, request={request_id}")
+            return previous_response
+    else:
+        logger.info(f"GET request for key={key} (no client ID)")
+
     value = storage.get(key)
     if value is None:
-        raise HTTPException(status_code=404, detail="Key not found")
-    return {"key": key, "value": value}
+        error_msg = f"Key not found: {key}"
+        logger.warning(error_msg)
+
+        response = {"status": "error", "message": error_msg}
+
+        # Cache error responses too
+        if client_id and request_id:
+            client_request = ClientRequest(client_id=client_id, request_id=request_id, operation="GET", key=key)
+            request_deduplication.mark_request_processed(client_request, response)
+
+        raise HTTPException(status_code=404, detail=error_msg)
+
+    # Create response
+    response = {"key": key, "value": value}
+
+    # Store response if client identifiers provided
+    if client_id and request_id:
+        client_request = ClientRequest(client_id=client_id, request_id=request_id, operation="GET", key=key)
+        request_deduplication.mark_request_processed(client_request, response)
+
+    return response
 
 
 @app.put("/key/{key}")
-def set_key(key: str, kv: KeyValue):
+def set_key(key: str, kv: KeyValue, client_id: Optional[str] = Query(None), request_id: Optional[str] = Query(None)):
+    # If client_id and request_id are provided, check for duplicate request
+    if client_id and request_id:
+        logger.info(f"SET request for key={key} from client={client_id}, request={request_id}")
+        previous_response = request_deduplication.get_processed_result(client_id, request_id)
+        if previous_response is not None:
+            logger.info(f"✅ Returning cached response for SET key={key}, client={client_id}, request={request_id}")
+            return previous_response
+    else:
+        logger.info(f"SET request for key={key} (no client ID)")
+
+    # Process the request normally
     entry = storage.set(key, kv.value)
+    logger.info(f"Added SET entry id={entry.id} for key={key}")
 
     # Replicate to followers asynchronously
-    # In a production system, you'd want to handle this more robustly
-    # (e.g., with a background task queue)
-    for follower_id, follower_url in followers.items():
-        try:
-            requests.post(f"{follower_url}/replicate", json={"entries": [entry.model_dump()]}, timeout=API_TIMEOUT)
-            replication_status[follower_id] = entry.id
-        except requests.RequestException:
-            # In production, you'd want better error handling and retry logic
-            pass
+    _replicate_to_followers(entry)
 
-    return {"status": "ok", "id": entry.id}
+    # Create response
+    response = {"status": "ok", "id": entry.id}
+
+    # If client tracking info was provided, store the response
+    if client_id and request_id:
+        client_request = ClientRequest(client_id=client_id, request_id=request_id, operation="SET", key=key, value=kv.value)
+        request_deduplication.mark_request_processed(client_request, response)
+        logger.info(f"Cached response for SET key={key}, client={client_id}, request={request_id}")
+
+    return response
 
 
 @app.delete("/key/{key}")
-def delete_key(key: str):
+def delete_key(key: str, client_id: Optional[str] = Query(None), request_id: Optional[str] = Query(None)):
+    # Check for duplicate request
+    if client_id and request_id:
+        logger.info(f"DELETE request for key={key} from client={client_id}, request={request_id}")
+        previous_response = request_deduplication.get_processed_result(client_id, request_id)
+        if previous_response is not None:
+            logger.info(f"✅ Returning cached response for DELETE key={key}, client={client_id}, request={request_id}")
+            return previous_response
+    else:
+        logger.info(f"DELETE request for key={key} (no client ID)")
+
+    # Process the request
     entry = storage.delete(key)
     if entry is None:
-        raise HTTPException(status_code=404, detail="Key not found")
+        error_msg = f"Key not found: {key}"
+        logger.warning(error_msg)
 
-    # Replicate deletion to followers
+        response = {"status": "error", "message": error_msg}
+        status_code = 404
+
+        # Cache the error response too if client tracking is enabled
+        if client_id and request_id:
+            client_request = ClientRequest(client_id=client_id, request_id=request_id, operation="DELETE", key=key)
+            request_deduplication.mark_request_processed(client_request, response)
+            logger.info(f"Cached error response for DELETE key={key}, client={client_id}, request={request_id}")
+
+        raise HTTPException(status_code=status_code, detail=error_msg)
+
+    logger.info(f"Added DELETE entry id={entry.id} for key={key}")
+
+    # Replicate to followers
+    _replicate_to_followers(entry)
+
+    # Create response
+    response = {"status": "ok", "id": entry.id}
+
+    # If client tracking info was provided, store the response
+    if client_id and request_id:
+        client_request = ClientRequest(client_id=client_id, request_id=request_id, operation="DELETE", key=key)
+        request_deduplication.mark_request_processed(client_request, response)
+        logger.info(f"Cached response for DELETE key={key}, client={client_id}, request={request_id}")
+
+    return response
+
+
+def _replicate_to_followers(entry):
+    """Helper method to replicate an entry to all followers"""
     for follower_id, follower_url in followers.items():
         try:
+            logger.info(f"Replicating entry id={entry.id} to follower {follower_id}")
             requests.post(
                 f"{follower_url}/replicate",
                 json={"entries": [entry.model_dump()]},
                 timeout=API_TIMEOUT,
             )
             replication_status[follower_id] = entry.id
-        except requests.RequestException:
+        except requests.RequestException as e:
+            logger.error(f"Failed to replicate entry id={entry.id} to follower {follower_id}: {str(e)}")
             # In production, you'd want better error handling and retry logic
-            pass
-
-    return {"status": "ok", "id": entry.id}
 
 
 @app.post("/register_follower")
@@ -113,3 +205,24 @@ def get_all_keys():
     """Return all keys in the storage"""
     keys = storage.get_all_keys()
     return {"keys": keys, "count": len(keys)}
+
+
+@app.get("/request_status")
+def get_request_status(client_id: str, request_id: str):
+    """Check if a client request has been processed"""
+    logger.info(f"Checking status for client={client_id}, request={request_id}")
+    result = request_deduplication.get_processed_result(client_id, request_id)
+    if result:
+        logger.info(f"Found cached result for client={client_id}, request={request_id}")
+        return {"processed": True, "result": result}
+    else:
+        logger.info(f"No cached result found for client={client_id}, request={request_id}")
+        return {"processed": False}
+
+
+@app.get("/deduplication_stats")
+def get_deduplication_stats():
+    """Return statistics about the request deduplication service"""
+    stats = request_deduplication.get_stats()
+    logger.info(f"Returning deduplication stats: duplicates detected={stats['total_duplicates_detected']}")
+    return stats

--- a/src/pydistributedkv/service/request_deduplication.py
+++ b/src/pydistributedkv/service/request_deduplication.py
@@ -1,0 +1,150 @@
+import logging
+import time
+from collections import defaultdict
+from typing import Any, Dict, Optional, Tuple
+
+from pydistributedkv.domain.models import ClientRequest
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+class RequestDeduplicationService:
+    """Service to track processed client requests and prevent duplicate processing"""
+
+    def __init__(self, max_cache_size: int = 10000, expiry_seconds: int = 3600, service_name: str = "deduplication"):
+        """
+        Initialize the request deduplication service.
+
+        Args:
+            max_cache_size: Maximum number of client requests to track
+            expiry_seconds: Time in seconds after which cached requests should expire
+            service_name: Name of the service using this deduplication (for logging)
+        """
+        self.processed_requests: Dict[str, Dict[str, Tuple[float, Any]]] = defaultdict(dict)
+        self.max_cache_size = max_cache_size
+        self.expiry_seconds = expiry_seconds
+        self.service_name = service_name
+
+        # Statistics
+        self.total_requests_cached = 0
+        self.total_duplicates_detected = 0
+        self.total_cache_cleanups = 0
+
+        logger.info(
+            f"[{service_name}] Request deduplication service initialized with max_cache_size={max_cache_size}, expiry_seconds={expiry_seconds}"
+        )
+
+    def mark_request_processed(self, client_request: ClientRequest, result: Any):
+        """Mark a client request as processed with its result"""
+        self._clean_expired_requests()
+
+        client_id = client_request.client_id
+        request_id = client_request.request_id
+        operation = client_request.operation or "UNKNOWN"
+        key = client_request.key or "N/A"
+
+        # Store the result with the current timestamp
+        self.processed_requests[client_id][request_id] = (time.time(), result)
+        self.total_requests_cached += 1
+
+        logger.info(f"[{self.service_name}] Cached result for client={client_id}, request={request_id}, operation={operation}, key={key}")
+
+        # If we've exceeded our cache size, remove the oldest entries
+        if len(self.processed_requests) > self.max_cache_size:
+            self._clean_oldest_requests()
+
+    def get_processed_result(self, client_id: str, request_id: str) -> Optional[Any]:
+        """
+        Check if a request has been processed and return its result if found
+
+        Returns:
+            The stored result if the request was already processed, None otherwise
+        """
+        self._clean_expired_requests()
+
+        if client_id in self.processed_requests and request_id in self.processed_requests[client_id]:
+            timestamp, result = self.processed_requests[client_id][request_id]
+            self.total_duplicates_detected += 1
+
+            # Calculate how long ago this request was first processed
+            time_since_original = time.time() - timestamp
+
+            logger.warning(
+                f"[{self.service_name}] DUPLICATE REQUEST DETECTED: client={client_id}, request={request_id}, "
+                f"originally processed {time_since_original:.2f} seconds ago"
+            )
+            return result
+
+        return None
+
+    def _clean_expired_requests(self):
+        """Remove expired entries from the cache"""
+        current_time = time.time()
+        clients_to_remove = []
+        expired_count = 0
+
+        for client_id, requests in self.processed_requests.items():
+            # Find expired requests for this client
+            expired_requests = [req_id for req_id, (timestamp, _) in requests.items() if current_time - timestamp > self.expiry_seconds]
+
+            # Remove expired requests
+            for req_id in expired_requests:
+                del requests[req_id]
+                expired_count += 1
+
+            # If client has no more requests, mark for removal
+            if not requests:
+                clients_to_remove.append(client_id)
+
+        # Remove empty client entries
+        for client_id in clients_to_remove:
+            del self.processed_requests[client_id]
+
+        if expired_count > 0:
+            logger.info(f"[{self.service_name}] Cleaned up {expired_count} expired cache entries")
+            self.total_cache_cleanups += 1
+
+    def _clean_oldest_requests(self):
+        """Remove the oldest entries when the cache exceeds max size"""
+        # Flatten all requests with their timestamps
+        all_requests = []
+        for client_id, requests in self.processed_requests.items():
+            for request_id, (timestamp, _) in requests.items():
+                all_requests.append((timestamp, client_id, request_id))
+
+        # Sort by timestamp (oldest first)
+        all_requests.sort()
+
+        # Remove oldest entries until we're within limits
+        entries_to_remove = max(0, len(all_requests) - self.max_cache_size)
+
+        if entries_to_remove > 0:
+            logger.info(f"[{self.service_name}] Cache size limit reached, removing {entries_to_remove} oldest entries")
+
+            for i in range(entries_to_remove):
+                _, client_id, request_id = all_requests[i]
+                if client_id in self.processed_requests and request_id in self.processed_requests[client_id]:
+                    del self.processed_requests[client_id][request_id]
+
+                    # If client has no more requests, remove the client entry
+                    if not self.processed_requests[client_id]:
+                        del self.processed_requests[client_id]
+
+            self.total_cache_cleanups += 1
+
+    def get_stats(self) -> dict:
+        """Return statistics about the deduplication service"""
+        total_cached = 0
+        for client_id, requests in self.processed_requests.items():
+            total_cached += len(requests)
+
+        return {
+            "service_name": self.service_name,
+            "current_cache_size": total_cached,
+            "total_client_count": len(self.processed_requests),
+            "total_requests_cached": self.total_requests_cached,
+            "total_duplicates_detected": self.total_duplicates_detected,
+            "total_cache_cleanups": self.total_cache_cleanups,
+        }

--- a/src/pydistributedkv/service/request_deduplication.py
+++ b/src/pydistributedkv/service/request_deduplication.py
@@ -168,7 +168,7 @@ class RequestDeduplicationService:
         total_cached = 0
         unique_request_ids = set()
 
-        for client_id, requests in self.processed_requests.items():
+        for _, requests in self.processed_requests.items():
             total_cached += len(requests)
             for req_id, _ in requests.keys():
                 unique_request_ids.add(req_id)

--- a/tests/service/test_request_deduplication.py
+++ b/tests/service/test_request_deduplication.py
@@ -1,0 +1,156 @@
+import time
+from unittest.mock import patch
+
+import pytest
+
+from pydistributedkv.domain.models import ClientRequest, OperationType
+from pydistributedkv.service.request_deduplication import RequestDeduplicationService
+
+
+class TestRequestDeduplicationService:
+    """Tests for the request deduplication service"""
+
+    @pytest.fixture
+    def dedup_service(self):
+        """Create a fresh deduplication service for each test"""
+        return RequestDeduplicationService(max_cache_size=10, expiry_seconds=1)
+
+    def test_basic_deduplication(self, dedup_service):
+        """Test that a request is correctly identified as a duplicate"""
+        # First request
+        client_request = ClientRequest(client_id="client1", request_id="req1", operation=OperationType.GET, key="test_key")
+        result = {"key": "test_key", "value": "test_value"}
+        dedup_service.mark_request_processed(client_request, result)
+
+        # Same request should be identified as duplicate
+        cached_result = dedup_service.get_processed_result("client1", "req1", OperationType.GET)
+        assert cached_result == result
+        assert dedup_service.total_duplicates_detected == 1
+        assert dedup_service.same_operation_duplicates == 1
+
+    def test_operation_type_differentiation(self, dedup_service):
+        """Test that different operation types with the same request ID are treated as different requests"""
+        # Mark a GET request as processed
+        get_request = ClientRequest(client_id="client1", request_id="req1", operation=OperationType.GET, key="test_key")
+        get_result = {"key": "test_key", "value": "test_value"}
+        dedup_service.mark_request_processed(get_request, get_result)
+
+        # Different operation with the same request ID should NOT be considered a duplicate
+        set_result = dedup_service.get_processed_result("client1", "req1", OperationType.SET)
+        assert set_result is None
+        assert dedup_service.different_operation_duplicates == 1
+
+        # But the GET operation should still be considered a duplicate
+        get_result_again = dedup_service.get_processed_result("client1", "req1", OperationType.GET)
+        assert get_result_again == get_result
+        assert dedup_service.same_operation_duplicates == 1
+
+    def test_different_clients_same_request_id(self, dedup_service):
+        """Test that the same request ID from different clients is treated as different requests"""
+        # First client request
+        client1_request = ClientRequest(client_id="client1", request_id="req1", operation=OperationType.GET, key="test_key")
+        client1_result = {"key": "test_key", "value": "client1_value"}
+        dedup_service.mark_request_processed(client1_request, client1_result)
+
+        # Second client with same request ID
+        client2_request = ClientRequest(client_id="client2", request_id="req1", operation=OperationType.GET, key="test_key")
+        client2_result = {"key": "test_key", "value": "client2_value"}
+        dedup_service.mark_request_processed(client2_request, client2_result)
+
+        # Both clients should get their own results
+        cached_result1 = dedup_service.get_processed_result("client1", "req1", OperationType.GET)
+        cached_result2 = dedup_service.get_processed_result("client2", "req1", OperationType.GET)
+
+        assert cached_result1 == client1_result
+        assert cached_result2 == client2_result
+        assert cached_result1 != cached_result2
+
+    def test_expiry_of_cached_results(self, dedup_service):
+        """Test that cached results expire after the configured time"""
+        # Set a very short expiry time for testing
+        dedup_service.expiry_seconds = 0.1
+
+        # Cache a request
+        client_request = ClientRequest(client_id="client1", request_id="req1", operation=OperationType.GET, key="test_key")
+        result = {"key": "test_key", "value": "test_value"}
+        dedup_service.mark_request_processed(client_request, result)
+
+        # Request should be cached initially
+        assert dedup_service.get_processed_result("client1", "req1", OperationType.GET) == result
+
+        # Wait for the cache to expire
+        time.sleep(0.2)
+
+        # After expiry, the result should be gone
+        assert dedup_service.get_processed_result("client1", "req1", OperationType.GET) is None
+
+    @patch("time.time")
+    def test_cache_cleanup_on_access(self, mock_time, dedup_service):
+        """Test that expired entries are cleaned up when accessing the cache"""
+        # Set up mock times
+        mock_time.return_value = 1000  # Starting time
+
+        # Cache a request
+        client_request = ClientRequest(client_id="client1", request_id="req1", operation=OperationType.GET, key="test_key")
+        result = {"key": "test_key", "value": "test_value"}
+        dedup_service.mark_request_processed(client_request, result)
+
+        # Add another entry
+        client_request2 = ClientRequest(client_id="client1", request_id="req2", operation=OperationType.GET, key="test_key2")
+        result2 = {"key": "test_key2", "value": "test_value2"}
+        dedup_service.mark_request_processed(client_request2, result2)
+
+        # Advance time beyond expiry
+        mock_time.return_value = 1000 + dedup_service.expiry_seconds + 1
+
+        # Access the cache, which should trigger cleanup
+        dedup_service.get_processed_result("client1", "req1", OperationType.GET)
+
+        # All entries should be gone
+        assert len(dedup_service.processed_requests) == 0
+        assert dedup_service.total_cache_cleanups >= 1
+
+    def test_same_request_different_operations(self, dedup_service):
+        """Test handling multiple operations on the same request ID"""
+        # First operation: SET
+        set_request = ClientRequest(
+            client_id="client1", request_id="req1", operation=OperationType.SET, key="test_key", value="initial_value"
+        )
+        set_result = {"status": "ok", "id": 1}
+        dedup_service.mark_request_processed(set_request, set_result)
+
+        # Second operation: DELETE
+        delete_request = ClientRequest(client_id="client1", request_id="req1", operation=OperationType.DELETE, key="test_key")
+        delete_result = {"status": "ok", "id": 2}
+        dedup_service.mark_request_processed(delete_request, delete_result)
+
+        # Each operation should have its own cached result
+        cached_set_result = dedup_service.get_processed_result("client1", "req1", OperationType.SET)
+        cached_delete_result = dedup_service.get_processed_result("client1", "req1", OperationType.DELETE)
+
+        assert cached_set_result == set_result
+        assert cached_delete_result == delete_result
+        assert cached_set_result != cached_delete_result
+
+    def test_get_stats(self, dedup_service):
+        """Test the statistics collection feature"""
+        # Cache a few different requests
+        for i in range(3):
+            client_request = ClientRequest(client_id="client1", request_id=f"req{i}", operation=OperationType.GET, key=f"key{i}")
+            dedup_service.mark_request_processed(client_request, {"value": f"value{i}"})
+
+        # Create some duplicates
+        dedup_service.get_processed_result("client1", "req0", OperationType.GET)
+        dedup_service.get_processed_result("client1", "req1", OperationType.GET)
+        dedup_service.get_processed_result("client1", "req0", OperationType.SET)  # Different operation
+
+        # Check stats
+        stats = dedup_service.get_stats()
+
+        assert stats["total_requests_cached"] == 3
+        assert stats["total_duplicates_detected"] == 2
+        assert stats["same_operation_duplicates"] == 2
+        assert stats["different_operation_duplicates"] == 1
+        assert stats["current_cache_size"] == 3
+        assert stats["unique_request_ids"] == 3
+        assert stats["total_client_count"] == 1


### PR DESCRIPTION
Closes #6 

> **Added feature:** Idempotent Receiver pattern for reliable client request handling.
This version implements the Idempotent Receiver pattern to handle duplicate client requests and ensure operations are only applied once:

* **Client Request Identification:** Each client request can now include a unique client ID and request ID.
* **Operation-Aware Deduplication:** The system tracks client requests by operation type (GET/SET/DELETE) to properly handle different operations with the same request ID.
* **Request Caching:** Responses are cached for a configurable period to immediately respond to duplicate requests.
* **Request Statistics:** New endpoints provide visibility into duplicate detection and request handling patterns.
* **Improved Reliability:** Clients can retry requests without worry of duplicate processing.

Benefits of the Idempotent Receiver pattern:
* Eliminates duplicate mutations when clients retry requests due to network issues
* Prevents accidental duplicate operations from users clicking twice
* Provides exactly-once semantics in an eventually consistent system
* Improves system robustness during network partitions or client timeouts

How it works:
1. Clients add `client_id` and `request_id` parameters to their requests
2. When the system first processes a request, it stores the result along with these identifiers
3. If the same request arrives again (same client_id, request_id, and operation), the cached result is returned
4. Different operations with the same request ID are tracked separately
5. Cached results expire after a configurable time period (default: 1 hour)

Example usage:

```bash
# First time - request is processed normally
curl -X PUT "http://localhost:8000/key/testkey?client_id=client1&request_id=req123" \
    -H "Content-Type: application/json" -d '{"value": "testvalue"}'

# Same request again - returns cached result without processing
curl -X PUT "http://localhost:8000/key/testkey?client_id=client1&request_id=req123" \
    -H "Content-Type: application/json" -d '{"value": "testvalue"}'

# Different operation type with same request ID - processed separately
curl -X DELETE "http://localhost:8000/key/testkey?client_id=client1&request_id=req123"

# Check deduplication statistics
curl http://localhost:8000/deduplication_stats
```

View request deduplication statistics:

```json
{
  "service_name": "leader",
  "current_cache_size": 2,
  "unique_request_ids": 1,
  "total_client_count": 1,
  "total_requests_cached": 2,
  "total_duplicates_detected": 1,
  "same_operation_duplicates": 1,
  "different_operation_duplicates": 1,
  "total_cache_cleanups": 0
}
```